### PR TITLE
use encoding of underlying levelup

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,6 +1,12 @@
 var tape = require('tape')
-var memdb = require('memdb')
+var mem = require('memdb')
 var changes = require('./')
+
+function memdb (opts) {
+  opts = opts || {}
+  opts.valueEncoding = opts.valueEncoding || 'binary'
+  return mem(opts)
+}
 
 tape('append and stream', function(t) {
   var feed = changes(memdb())
@@ -87,6 +93,20 @@ tape('limit', function(t) {
         t.same(changes[0], {change:1, value:new Buffer('hello')})
         t.end()
       })
+    })
+  })
+})
+
+tape('json valueEncoding', function(t) {
+  var feed = changes(memdb({ valueEncoding: 'json' }))
+  var data = { hello: 'world' }
+
+  feed.append(data, function() {
+    feed.createReadStream({ limit: 1 }, function(err, changes) {
+      t.notOk(err, 'no err')
+      t.same(changes.length, 1, 'limited to 1 change')
+      t.same(changes[0], { change:1, value: data })
+      t.end()
     })
   })
 })


### PR DESCRIPTION
so you can do 

``` js
var db = level('blah.db', { valueEncoding: 'json' })
var feed = changes(db)
feed.append({ hey: 'ho' })
feed.createReadStream()
  .on('data', console.log) 
// { change: 1, value: { hey: 'ho' } }
```

this would mean for binary, you'd have to explicitly specify level('path', { valueEncoding: 'binary' })
